### PR TITLE
fix(readme): Update david-dm badge format

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License](http://img.shields.io/badge/license-MIT-blue.svg?style=flat)](https://github.com/paradox41/app-template)
 [![Tag](https://img.shields.io/github/tag/paradox41/app-template.svg?style=flat)](https://github.com/paradox41/app-template)
 [![Build](https://travis-ci.org/paradox41/app-template.svg)](https://travis-ci.org/paradox41/app-template)
-[![David](https://david-dm.org/paradox41/app-template.svg)](https://github.com/paradox41/app-template)
+[![Dependency Status](https://david-dm.org/paradox41/app-template.svg)](https://david-dm.org/paradox41/app-template)
 
 Boilerplate for my Angular apps
 


### PR DESCRIPTION
The format provided by david-dm has changed slightly and now links to a dependency report card.