### PR TITLE
fix(karma): fixes webpack error "Module not found"

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -15,13 +15,13 @@ module.exports = function(config) {
         ],
 
         files: [
-            'app/app.spec.js'
+            'test.spec.js'
         ],
 
         exclude: [],
 
         preprocessors: {
-            'app/app.spec.js': ['webpack', 'sourcemap', 'coverage']
+            'test.spec.js': ['webpack', 'sourcemap', 'coverage']
         },
 
         webpack: require('./webpack.test.config.js'),

--- a/test.spec.js
+++ b/test.spec.js
@@ -1,4 +1,4 @@
-var context = require.context('.', true, /\.spec\.js$/);
+var context = require.context('./app', true, /\.spec\.js$/);
 
 context.keys().forEach(context);
 


### PR DESCRIPTION
"Module not found: Error: a dependency to an entry point is not allowed" was the full error.

There seemed to be an issue with app.spec.js living in ./app/ while using the var context = require.context('./', true, /\.spec\.js$/); test registration pattern.